### PR TITLE
mullvad.openvpn: init at 2.5.3

### DIFF
--- a/pkgs/applications/networking/mullvad/default.nix
+++ b/pkgs/applications/networking/mullvad/default.nix
@@ -4,4 +4,5 @@
 lib.makeScope newScope (self: {
   libwg = self.callPackage ./libwg.nix { };
   mullvad = self.callPackage ./mullvad.nix { };
+  openvpn-mullvad = self.callPackage ./openvpn.nix { };
 })

--- a/pkgs/applications/networking/mullvad/mullvad.nix
+++ b/pkgs/applications/networking/mullvad/mullvad.nix
@@ -10,6 +10,7 @@
 , libnftnl
 , libmnl
 , libwg
+, openvpn-mullvad
 }:
 let
   # result of running address_cache as of 02 Mar 2022
@@ -87,6 +88,8 @@ rustPlatform.buildRustPackage rec {
       wrapProgram $out/bin/mullvad-daemon \
         --set-default MULLVAD_RESOURCE_DIR "$out/share"
     '';
+
+  passthru = { inherit openvpn-mullvad; };
 
   meta = with lib; {
     description = "Mullvad VPN command-line client tools";

--- a/pkgs/applications/networking/mullvad/openvpn.nix
+++ b/pkgs/applications/networking/mullvad/openvpn.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchpatch
+, fetchurl
+, openvpn
+, autoconf
+, automake
+}:
+
+openvpn.overrideAttrs (oldAttrs:
+  let
+    fetchMulvadPatch = { commit, sha256 }: fetchpatch {
+      url = "https://github.com/mullvad/openvpn/commit/${commit}.patch";
+      inherit sha256;
+    };
+  in
+  rec {
+    version = "2.5.3";
+
+    src = fetchurl {
+      url = "https://swupdate.openvpn.net/community/releases/openvpn-${version}.tar.gz";
+      sha256 = "sha256-dfAETfRJQwVVynuZWit3qyTylG/cNmgwG47cI5hqX34=";
+    };
+
+    patches = oldAttrs.patches or [ ] ++ [
+      # look at compare to find the relevant commits
+      # https://github.com/OpenVPN/openvpn/compare/release/2.5...mullvad:mullvad-patches
+      # used openvpn version is the latest tag ending with -mullvad
+      # https://github.com/mullvad/openvpn/tags
+      (fetchMulvadPatch {
+        commit = "41e44158fc71bb6cc8cc6edb6ada3307765a12e8";
+        sha256 = "sha256-UoH0V6gTPdEuybFkWxdaB4zomt7rZeEUyXs9hVPbLb4=";
+      })
+      (fetchMulvadPatch {
+        commit = "f51781c601e8c72ae107deaf25bf66f7c193e9cd";
+        sha256 = "sha256-+kwG0YElL16T0e+avHlI8gNQdAxneRS6fylv7QXvC1s=";
+      })
+      (fetchMulvadPatch {
+        commit = "c2f810f966f2ffd68564d940b5b8946ea6007d5a";
+        sha256 = "sha256-PsKIxYwpLD66YaIpntXJM8OGcObyWBSAJsQ60ojvj30=";
+      })
+      (fetchMulvadPatch {
+        commit = "879d6a3c0288b5443bbe1b94261655c329fc2e0e";
+        sha256 = "sha256-pRFY4r+b91/xAKXx6u5GLzouQySXuO5gH0kMGm77a3c=";
+      })
+      (fetchMulvadPatch {
+        commit = "7f71b37a3b25bec0b33a0e29780c222aef869e9d";
+        sha256 = "sha256-RF/GvD/ZvhLdt34wDdUT/yxa+IVWx0eY6WRdNWXxXeQ=";
+      })
+      (fetchMulvadPatch {
+        commit = "abd3c6214529d9f4143cc92dd874d8743abea17c";
+        sha256 = "sha256-SC2RlpWHUDMAEKap1t60dC4hmalk3vok6xY+/xhC2U0=";
+      })
+      (fetchMulvadPatch {
+        commit = "b45b090c81e7b4f2dc938642af7a1e12f699f5c5";
+        sha256 = "sha256-KPTFmbuJhMI+AvaRuu30CPPLQAXiE/VApxlUCqbZFls=";
+      })
+    ];
+
+    nativeBuildInputs = oldAttrs.nativeBuildInputs ++ [
+      autoconf
+      automake
+    ];
+  })


### PR DESCRIPTION
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->

###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
